### PR TITLE
Correção: Atualização de campos obrigatórios (faixa salarial e benefícios) e troca do default do campo (vaga afirmativa)

### DIFF
--- a/src/components/AddJobs/FormSteps/StepThree.tsx
+++ b/src/components/AddJobs/FormSteps/StepThree.tsx
@@ -137,7 +137,6 @@ const StepThree = ({
                         {...register('affirmative')}
                         type="radio"
                         value="true"
-                        defaultChecked
                         name="affirmative"
                     />
                     Sim
@@ -147,6 +146,7 @@ const StepThree = ({
                         {...register('affirmative')}
                         type="radio"
                         value="false"
+                        defaultChecked
                         name="affirmative"
                     />
                     Não

--- a/src/components/AddJobs/FormSteps/StepTwo.tsx
+++ b/src/components/AddJobs/FormSteps/StepTwo.tsx
@@ -44,7 +44,7 @@ const StepTwo = ({
     return (
         <>
             <SalarySection>
-                <Label>*Faixa Salarial: </Label>
+                <Label>Faixa Salarial: </Label>
                 <SalaryInputContainer>
                     <div>
                         <Controller

--- a/src/validations/JobFormValidations/index.ts
+++ b/src/validations/JobFormValidations/index.ts
@@ -2,7 +2,7 @@ import * as yup from 'yup';
 
 export const createJobForm = yup.object().shape({
     title: yup
-        .string()
+        .string() 
         .required('O título é obrigatório')
         .max(30, 'O título deve ter no máximo 30 caracteres'),
     description: yup
@@ -15,12 +15,13 @@ export const createJobForm = yup.object().shape({
         .max(3000, 'Este campo deve ter no máximo 3000 caracteres'),
     benefits: yup
         .string()
+        .notRequired()
         .max(3000, 'Este campo deve ter no máximo 3000 caracteres'),
     salaryMin: yup
         .number()
         .typeError('O valor mínimo deve ser um número')
         .positive('O valor mínimo deve ser positivo')
-        .required('O valor mínimo é obrigatório')
+        .notRequired()
         .test(
             'min-max-salaryMin',
             'O valor mínimo deve ser menor que o valor máximo',
@@ -32,9 +33,10 @@ export const createJobForm = yup.object().shape({
     salaryMax: yup
         .number()
         .typeError('O valor máximo deve ser um número')
-        .positive('O valor máximo deve ser positivo')
-        .required('O valor máximo é obrigatório'),
-    type: yup.string().required('A opção é obrigatória'),
+        .positive('O valor máximo deve ser positivo'),
+
+    type: yup.string().required('O tipo é obrigatório'),
+
     typeContract: yup
             .mixed()
             .oneOf(['CLT', 'PJ', 'Outro'], 'Selecione uma opção válida')


### PR DESCRIPTION
[Empresa] - Criar vaga #3

## Descrição
Após testes de usabilidade, foi analisado inconsistências nos itens:

Faixa salarial indicado como preenchimento obrigatório. Segundo o critério de aceite 2, os itens "Faixa salarial" e "Benefícios" não são de preenchimento obrigatório;
 A resposta para opção de vaga afirmativa está "Sim" como Default. Segundo o critério de aceite 17, a opção "Não" está descrito como default
___
## Mudanças
Foi alterado/corrigido os campos obrigatórios de Faixa Salarial e Benefícios passando a serem "não obrigatórios" e a opção default do campo "vaga afirmativa" foi trocado de 'sim' para 'não' como sendo o default

- [x] Faixa salarial e Benefícios não obrigatórios
- [x] Default "não" do campo de vaga afirmativa

## Prints
![image](https://github.com/SouJunior/vagas-frontend/assets/78991418/bbc65e52-d935-40c7-8534-0705494590d1)
![image](https://github.com/SouJunior/vagas-frontend/assets/78991418/f1502579-b828-48ad-993c-b498b3210aee)


